### PR TITLE
COOK-001 fixed bug that caused a recipe showing up twice after creating it [PS]

### DIFF
--- a/client/src/modules/recipes/recipesActions.js
+++ b/client/src/modules/recipes/recipesActions.js
@@ -84,7 +84,8 @@ export const addRecipe = (dispatch, recipe) => {
 
     dispatch({type: ADD_RECIPE});
 
-    dispatch({type: ADD_RECIPE_SUCCESS, recipe});
+    // add recipe after server responded
+    // dispatch({type: ADD_RECIPE_SUCCESS, recipe});
 
     // number steps
     recipe.steps.map((step, index) => recipe.steps[index].number = index + 1);


### PR DESCRIPTION
There was a bug that caused a newly created recipe showing up twice in the recipe overview. This happened, because the ADD_RECIPE_SUCCESS git dispatched twice.

1) When calling addRecipe()
2) After the server returned the added recipe

Removing case 1) resolves the issue. You could argue that removing case 2) has also some benefits over removing the first one, but I think that only adding a recipe that has been approved by the server is the way to go.